### PR TITLE
Add connection parameters to the websocket scope

### DIFF
--- a/starlette_graphene3.py
+++ b/starlette_graphene3.py
@@ -155,6 +155,7 @@ class GraphQLApp:
         message_type = cast(str, message.get("type"))
 
         if message_type == GQL_CONNECTION_INIT:
+            websocket.scope["connection_params"] = message.get("payload")
             await websocket.send_json({"type": GQL_CONNECTION_ACK})
         elif message_type == GQL_CONNECTION_TERMINATE:
             await websocket.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ class Query(graphene.ObjectType):
     me = graphene.Field(User)
     user = graphene.Field(User, id=graphene.ID(required=True))
     user_async = graphene.Field(User, id=graphene.ID(required=True))
+    show_connection_params = graphene.Field(graphene.String)
 
     def resolve_me(root, info):
         return {"id": "john", "name": "John"}
@@ -27,6 +28,9 @@ class Query(graphene.ObjectType):
 
     async def resolve_user_async(root, info, id):
         return {"id": id, "name": id.capitalize()}
+
+    def resolve_show_connection_params(root, info):
+        return str(info.context["request"].scope["connection_params"])
 
 
 class FileUploadMutation(graphene.Mutation):

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -232,3 +232,27 @@ def test_query_over_ws_with_variables_and_opname(client):
         assert msg["id"] == "q1"
         assert msg["payload"]["data"]["user"]["name"] == "Bob"
         ws.send_json({"type": GQL_CONNECTION_TERMINATE})
+
+
+def test_connection_params(client):
+    with client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT, "payload": {"authToken": "dummy"}})
+        msg = ws.receive_json()
+        assert msg["type"] == GQL_CONNECTION_ACK
+        ws.send_json(
+            {
+                "type": GQL_START,
+                "id": "q1",
+                "payload": {
+                    "query": r"query { showConnectionParams }",
+                    "operationName": None,
+                },
+            }
+        )
+        msg = ws.receive_json()
+        assert msg["type"] == GQL_DATA
+        assert msg["id"] == "q1"
+        assert (
+            msg["payload"]["data"]["showConnectionParams"] == "{'authToken': 'dummy'}"
+        )
+        ws.send_json({"type": GQL_CONNECTION_TERMINATE})


### PR DESCRIPTION
The Apollo client supports [a websocket authentication method](https://www.apollographql.com/docs/react/data/subscriptions/#4-authenticate-over-websocket-optional) by passing "connection parameters" to the client, that end up in the `connection_init` message.

This changeset makes those parameters available in the WebSocket request's scope.