### PR TITLE
Don't return a 400 status code on errors

### DIFF
--- a/starlette_graphene3.py
+++ b/starlette_graphene3.py
@@ -125,10 +125,9 @@ class GraphQLApp:
         if result.errors:
             response["errors"] = [format_error(error) for error in result.errors]
 
-        status_code = 200 if not result.errors else 400
         return JSONResponse(
             response,
-            status_code=status_code,
+            status_code=200,
             background=context_value.get("background"),
         )
 

--- a/tests/test_http_json.py
+++ b/tests/test_http_json.py
@@ -24,7 +24,7 @@ def test_http_json_arg_async(client):
 
 def test_http_json_invalid_query(client):
     res = client.post("/", json={"query": r"query { user { name } }"})
-    assert res.status_code == 400
+    assert res.status_code == 200
     result = res.json()
     assert "errors" in result
 


### PR DESCRIPTION
The GraphQL standard does not define the HTTP status code that should be returned on errors, but the libraries tend to return 200 and use the `errors` dictionary to signal errors.

Apollo will consider that 4xx and 5xx codes are errors and will not process the result as it would, reporting errors in the `errors` dict.

I can think of two other good reasons to return a 200 code on errors:

- GraphQL allows partial results, a response is thus not only good or bad
- Even if it's not supported right now by this library, GraphQL allows multiple queries in the same request. If one queries succeeds and the other fails, it seems incorrect to return a 400 error code.