### PR TITLE
Throw an exception on file absence in multipart

### DIFF
--- a/starlette_graphene3.py
+++ b/starlette_graphene3.py
@@ -421,9 +421,15 @@ async def _get_operation_from_multipart(request: Request):
 
     files = {k: v for (k, v) in request_body.items() if isinstance(v, UploadFile)}
     for (name, paths) in name_path_map.items():
+        file = files.get(name)
+        if not file:
+            raise ValueError(
+                f"File fields don't contain a valid UploadFile type for '{name}' mapping"
+            )
+
         for path in paths:
             path = tuple(path.split("."))
-            _inject_file_to_operations(operations, files[name], path)
+            _inject_file_to_operations(operations, file, path)
 
     return operations
 


### PR DESCRIPTION
Throws an error in case of a malformed request with incorrect or absent file fields for correspondent keys in the `map`.