### PR TITLE
GraphQL fetcher should honor headers from headers editor

### DIFF
--- a/src/starlette_graphene3.py
+++ b/src/starlette_graphene3.py
@@ -539,8 +539,6 @@ _GRAPHIQL_HTML = """
   <link href="//unpkg.com/graphiql/graphiql.css" rel="stylesheet"/>
   <script src="//unpkg.com/react@16/umd/react.production.min.js"></script>
   <script src="//unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
-  <script src="//unpkg.com/subscriptions-transport-ws@0.7.0/browser/client.js"></script>
-  <script src="//unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
 </head>
 <body>
   <script src="//unpkg.com/graphiql/graphiql.min.js"></script>
@@ -588,10 +586,11 @@ _GRAPHIQL_HTML = """
     ).join('&');
 
     // Defines a GraphQL fetcher using the fetch API.
-    function graphQLFetcher(graphQLParams) {
+    function graphQLFetcher(graphQLParams, {headers}) {
       var headers = {
         'Accept': 'application/json',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...headers,
       };
       if (csrftoken) {
         headers['X-CSRFToken'] = csrftoken;
@@ -640,11 +639,9 @@ _GRAPHIQL_HTML = """
     function updateURL() {
       history.replaceState(null, null, locationQuery(parameters));
     }
-    var subscriptionsEndpoint = (location.protocol === 'http:' ? 'ws' : 'wss') + '://' + location.host + location.pathname;
-    var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(subscriptionsEndpoint, {
-      reconnect: true
-    });
-    var fetcher = window.GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, graphQLFetcher);
+    var fetcher = window.GraphiQL.createFetcher({
+        url: location.protocol + "//" + location.host + location.pathname,
+    })
 
     // Render <GraphiQL /> into the body.
     ReactDOM.render(


### PR DESCRIPTION
This PR aims to fix #28.

Seems like this library uses an ancient GraphiQL setup. This PR updates some of that on the way to supporting making the headers editor work appropriately.

It tries to follow the "out of the box" implementation here https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html#L60, as referenced in this GraphiQL issue related to missing headers: https://github.com/graphql/graphiql/issues/3005#issuecomment-1436106973

It seems like subscriptions are handled within `GraphiQL` these days, so the couple of subscription packages have been removed. They are also no longer supported and have been archived on github:
- https://github.com/apollographql/subscriptions-transport-ws (archived Apr 14, 2023)
- https://github.com/apollographql/GraphiQL-Subscriptions-Fetcher (archived Jul 9, 2019)

In my local testing this seems to work well, but it's worth noting that my test apps don't leverage subscriptions so there could be something askew in that regard. Any feedback is welcome.